### PR TITLE
Disabling imports processing by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
 
 var compile = require('myth');
+var defaults = require('defaults');
 
 /**
  * Export `plugin`
@@ -11,18 +12,28 @@ var compile = require('myth');
 module.exports = plugin;
 
 /**
+ * Default options.
+ */
+
+plugin.defaults = {
+  features: {
+    import: false
+  }
+};
+
+/**
  * Myth plugin
  *
- * @param {Object} opts
+ * @param {Object} o
  * @return {String}
  */
 
-function plugin(opts) {
-  opts = opts || {};
+function plugin(o) {
+  var opts = defaults(o, plugin.defaults);
 
   return function myth(file) {
     if ('css' != file.type) return;
-    opts.source = file.path;
-    file.src = compile(file.src, opts);
+    var options = defaults(opts, { source: file.path });
+    file.src = compile(file.src, options);
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/MatthewMueller/duo-myth.git"
   },
   "dependencies": {
+    "defaults": "^1.0.0",
     "myth": "^1.2.1"
   },
   "devDependencies": {

--- a/test/import/foo.css
+++ b/test/import/foo.css
@@ -1,4 +1,5 @@
 :root {
+  --red: #ff0000;
   --green: #a6c776;
 }
 

--- a/test/import/index.css
+++ b/test/import/index.css
@@ -1,8 +1,5 @@
-:root {
-  --red: #ff0000;
-}
 
-@import "foo.css";
+@import "./foo.css";
 
 .foo {
   background-color: black;


### PR DESCRIPTION
Since duo handles imports on it's own, it seems reasonable for the *default* behavior to be to bypass using myth to process imports. #5 