### PR TITLE
Converting into an alternate plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
+NODE ?= node
+NODE_FLAGS ?= $(shell $(NODE) --v8-options | grep generators | cut -d ' ' -f 3)
+
 BIN := ./node_modules/.bin
-MOCHA ?= $(BIN)/mocha
+MOCHA ?= $(NODE) $(NODE_FLAGS) $(BIN)/_mocha
 
 test:
 	@$(MOCHA)

--- a/Readme.md
+++ b/Readme.md
@@ -2,12 +2,12 @@
 
 # duo-myth
 
-  duo plugin for [segmentio/myth](https://github.com/segmentio/myth).
+> duo plugin for [segmentio/myth](https://github.com/segmentio/myth).
 
 ## Installation
 
 ```bash
-npm install duo-myth
+$ npm install duo-myth
 ```
 
 ## Usage
@@ -34,11 +34,21 @@ Duo(root)
 
 Initialize a duo plugin. `opts` are passed directly into myth.
 
+## Plugin Architecture
+
+**NOTICE:** as of v0.1.0, this plugin acts as an
+[alternate plugin](https://github.com/duojs/duo/blob/master/docs/plugins.md#alternate-plugins),
+meaning it does a **single compile** on the entire build, instead of being run
+for every single file. (which is the default style of plugin)
+
+This allows some better default behavior for a CSS preprocessor, such as sharing
+variables across an entire tree of CSS files.
+
 ## Test
 
 ```bash
 $ npm install
-$ make
+$ make test
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = plugin;
  */
 
 plugin.defaults = {
+  alternate: false,
   features: {
     import: false
   }
@@ -31,9 +32,14 @@ plugin.defaults = {
 function plugin(o) {
   var opts = defaults(o, plugin.defaults);
 
-  return function myth(file) {
-    if ('css' != file.type) return;
-    var options = defaults(opts, { source: file.path });
-    file.src = compile(file.src, options);
+  // this plugin only works on the entire build
+  myth.alternate = true;
+  return myth;
+
+  function myth(build, entry) {
+    if (entry.type !== 'css') return;
+
+    var options = defaults(opts, { source: entry.path });
+    build.code = compile(build.code, options);
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "myth": "^1.2.1"
   },
   "devDependencies": {
+    "bluebird": "^2.9.21",
     "duo": "^0.11.1",
+    "gnode": "^0.1.1",
     "mocha": "^2.2.1"
   },
   "main": "index"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "myth": "^1.2.1"
   },
   "devDependencies": {
-    "mocha": "^2.0.1",
-    "duo": "^0.8.5"
+    "duo": "^0.11.1",
+    "mocha": "^2.2.1"
   },
   "main": "index"
 }

--- a/test/alternate-plugin/build.css
+++ b/test/alternate-plugin/build.css
@@ -1,0 +1,7 @@
+body {
+  color: #ff0000;
+}
+
+body {
+  background-color: #a6c776;
+}

--- a/test/alternate-plugin/index.css
+++ b/test/alternate-plugin/index.css
@@ -1,0 +1,10 @@
+:root {
+  --red: #ff0000;
+  --green: #a6c776;
+}
+
+@import "./page.css";
+
+body {
+  background-color: var(--green);
+}

--- a/test/alternate-plugin/page.css
+++ b/test/alternate-plugin/page.css
@@ -1,0 +1,3 @@
+body {
+  color: var(--red);
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
+--require gnode
 --reporter spec

--- a/test/myth.js
+++ b/test/myth.js
@@ -22,7 +22,7 @@ describe('duo-myth', function() {
       .entry(fixture('simple/index.css'))
       .run(function(err, css) {
         if (err) return done(err);
-        assert.equal(css.trim(), expected.trim());
+        assert.equal(css.code.trim(), expected.trim());
         done();
       });
   })
@@ -35,10 +35,23 @@ describe('duo-myth', function() {
       .entry(fixture('import/index.css'))
       .run(function(err, css) {
         if (err) return done(err);
-        assert.equal(css.trim(), expected.trim());
+        assert.equal(css.code.trim(), expected.trim());
         done();
       });
   })
+
+  it('should process the entire build', function(done) {
+    var expected = read(fixture('alternate-plugin/build.css'), 'utf8');
+
+    Duo(__dirname)
+      .use(myth())
+      .entry(fixture('alternate-plugin/index.css'))
+      .run(function (err, css) {
+        if (err) return done(err);
+        assert.equal(css.code.trim(), expected.trim());
+        done();
+      });
+  });
 
   it('should pass options through', function(done) {
     Duo(__dirname)
@@ -46,7 +59,7 @@ describe('duo-myth', function() {
       .entry('body {\n\tbackground: blue;\n}', 'css')
       .run(function(err, css) {
         if (err) return done(err);
-        assert.equal('body{background:blue;}', css);
+        assert.equal('body{background:blue;}', css.code);
         done();
       });
   })


### PR DESCRIPTION
This converts into an "alternate plugin", which I think is a much better default for a CSS preprocessor like this.