### PR TITLE
Add Cache Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
  * Module Dependencies
  */
 
-var compile = require('myth');
-var defaults = require('defaults');
+var debug = require('debug')('duo-myth');
+var extend = require('extend');
+var myth = require('myth');
 
 /**
  * Export `plugin`
@@ -16,30 +17,74 @@ module.exports = plugin;
  */
 
 plugin.defaults = {
-  alternate: false,
   features: {
     import: false
   }
 };
 
 /**
- * Myth plugin
+ * Myth plugin.
  *
  * @param {Object} o
  * @return {String}
  */
 
 function plugin(o) {
-  var opts = defaults(o, plugin.defaults);
+  var opts = extend(true, {}, plugin.defaults, o);
 
   // this plugin only works on the entire build
   myth.alternate = true;
   return myth;
 
-  function myth(build, entry) {
+  function *myth(build, entry, duo) {
     if (entry.type !== 'css') return;
 
-    var options = defaults(opts, { source: entry.path });
-    build.code = compile(build.code, options);
+    debug('processing build for %s', entry.id);
+    build.code = yield run(build.code, entry, duo, opts);
   }
+}
+
+/**
+ * Runs the majority of the logic for the plugin, including
+ * the compilation and managing the cache.
+ *
+ * @param {Object} build
+ * @param {File} entry
+ * @param {Duo} duo
+ * @param {Object} options
+ * @return {String}
+ */
+
+function *run(code, entry, duo, options) {
+  var cache = yield duo.getCache();
+  if (!cache) {
+    debug('cache not enabled for %s', entry.id);
+    return compile(code, entry, options);
+  }
+
+  var key = [ duo.hash(code), duo.hash(options) ];
+  var cached = yield cache.plugin('myth', key);
+  if (cached) {
+    debug('retrieved %s from cache', entry.id);
+    return cached;
+  }
+
+  var results = compile(code, entry, options);
+  yield cache.plugin('myth', key, results);
+  debug('saved %s to cache', entry.id);
+  return results;
+}
+
+/**
+ * Perform the actual compilation given all the context.
+ *
+ * @param {String) code
+ * @param {File} entry
+ * @param {Object} options
+ * @return {String}
+ */
+
+function compile(code, entry, options) {
+  var o = extend(true, { source: entry.path }, options);
+  return myth(code, o);
 }

--- a/package.json
+++ b/package.json
@@ -2,20 +2,22 @@
   "name": "duo-myth",
   "version": "0.1.0",
   "description": "duo plugin for segmentio/myth",
-  "keywords": [],
+  "keywords": [ "duo", "myth", "plugin", "alternate" ],
   "author": "Matthew Mueller <mattmuelle@gmail.com>",
   "repository": "duojs/myth",
   "dependencies": {
-    "defaults": "^1.0.0",
+    "debug": "^2.2.0",
+    "extend": "^3.0.0",
     "myth": "^1.2.1"
   },
   "devDependencies": {
     "bluebird": "^2.9.21",
-    "duo": "^0.11.1",
+    "co-mocha": "~1.0.3",
+    "duo": "^0.13.1",
     "eslint": "^0.24.0",
     "eslint-config-duo": "0.0.1",
     "gnode": "^0.1.1",
-    "mocha": "^2.2.1"
-  },
-  "main": "index"
+    "mocha": "^2.2.1",
+    "rimraf": "^2.4.1"
+  }
 }

--- a/test/cache/index.css
+++ b/test/cache/index.css
@@ -1,0 +1,33 @@
+
+:root {
+  --green: #a6c776;
+}
+
+@custom-media --narrow-window screen and (max-width: 30em);
+
+@media (--narrow-window) {
+  html {
+    font-size: 1.2rem;
+  }
+}
+
+a {
+  color: var(--green);
+  font-variant: all-small-caps;
+  transition: color 1s;
+  box-sizing: border-box;
+  border-radius: 3px;
+}
+
+a:hover {
+  color: color(var(--green) shade(20%));
+}
+
+::placeholder {
+  opacity: .4;
+  transition: opacity 1s;
+}
+
+:focus::placeholder {
+  opacity: .2;
+}

--- a/test/compress/build.css
+++ b/test/compress/build.css
@@ -1,0 +1,1 @@
+body{background:blue;}

--- a/test/compress/index.css
+++ b/test/compress/index.css
@@ -1,0 +1,4 @@
+
+body {
+  background: blue;
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
+--require co-mocha
 --require gnode
---reporter spec

--- a/test/myth.js
+++ b/test/myth.js
@@ -2,65 +2,88 @@
  * Module Dependencies
  */
 
-var read = require('fs').readFileSync;
-var join = require('path').join;
-var fixture = join.bind(null, __dirname);
 var assert = require('assert');
-var myth = require('..');
 var Duo = require('duo');
+var myth = require('..');
+var path = require('path');
+var read = require('fs').readFileSync;
 
-/**
- * Tests
- */
+var fixture = path.join.bind(null, __dirname);
 
 describe('duo-myth', function() {
-  it('should compile .css', function(done) {
+  it('should compile .css', function*() {
     var expected = read(fixture('simple/build.css'), 'utf8');
-
-    Duo(__dirname)
-      .use(myth())
-      .entry(fixture('simple/index.css'))
-      .run(function(err, css) {
-        if (err) return done(err);
-        assert.equal(css.code.trim(), expected.trim());
-        done();
-      });
+    var css = yield build('simple').run();
+    assert.equal(css.code.trim(), expected.trim());
   });
 
-  it('should compile .css using imports', function(done) {
+  it('should compile .css using imports', function*() {
     var expected = read(fixture('import/build.css'), 'utf8');
-
-    Duo(__dirname)
-      .use(myth())
-      .entry(fixture('import/index.css'))
-      .run(function(err, css) {
-        if (err) return done(err);
-        assert.equal(css.code.trim(), expected.trim());
-        done();
-      });
+    var css = yield build('import').run();
+    assert.equal(css.code.trim(), expected.trim());
   });
 
-  it('should process the entire build', function(done) {
+  it('should process the entire build', function*() {
     var expected = read(fixture('alternate-plugin/build.css'), 'utf8');
 
-    Duo(__dirname)
-      .use(myth())
-      .entry(fixture('alternate-plugin/index.css'))
-      .run(function (err, css) {
-        if (err) return done(err);
-        assert.equal(css.code.trim(), expected.trim());
-        done();
-      });
+    var css = yield build('alternate-plugin').run();
+    assert.equal(css.code.trim(), expected.trim());
   });
 
-  it('should pass options through', function(done) {
-    Duo(__dirname)
-      .use(myth({ compress: true }))
-      .entry('body {\n\tbackground: blue;\n}', 'css')
-      .run(function(err, css) {
-        if (err) return done(err);
-        assert.equal('body{background:blue;}', css.code);
-        done();
-      });
+  it('should pass options through', function*() {
+    var expected = read(fixture('compress/build.css'), 'utf8');
+    var css = yield build('compress', { compress: true }).run();
+    assert.equal(css.code.trim(), expected.trim());
+  });
+
+  describe.only('with caching enabled', function() {
+    afterEach(function *() {
+      yield build('simple').cache(true).cleanCache();
+    });
+
+    it('should be significantly faster', function*() {
+      var duo = build('simple', { compress: true }).cache(true);
+
+      var timer1 = timer();
+      yield duo.run();
+      var noCache = timer1();
+
+      var timer2 = timer();
+      yield duo.run();
+      var withCache = timer2();
+
+      console.log('with cache: %d -- no cache: %d', withCache, noCache);
+      assert(withCache < noCache / 2);
+    });
   });
 });
+
+/**
+ * Helper for creating a Duo builder instance.
+ *
+ * @param {String} entry      The fixture entry file to use
+ * @param {Object} [options]  Additional config
+ * @return {Duo}
+ */
+
+function build(entry, options) {
+  return new Duo(__dirname)
+    .cache(false)
+    .use(myth(options))
+    .entry(fixture(entry, 'index.css'));
+}
+
+/**
+ * Create a timer. The function returned should be called
+ * later and it will return the number of ms since it was
+ * created.
+ *
+ * @returns {Function}
+ */
+
+function timer() {
+  var now = (new Date()).getTime();
+  return function () {
+    return (new Date()).getTime() - now;
+  };
+}

--- a/test/myth.js
+++ b/test/myth.js
@@ -36,7 +36,7 @@ describe('duo-myth', function() {
     assert.equal(css.code.trim(), expected.trim());
   });
 
-  describe.only('with caching enabled', function() {
+  describe('with caching enabled', function() {
     afterEach(function *() {
       yield build('simple').cache(true).cleanCache();
     });
@@ -52,7 +52,6 @@ describe('duo-myth', function() {
       yield duo.run();
       var withCache = timer2();
 
-      console.log('with cache: %d -- no cache: %d', withCache, noCache);
       assert(withCache < noCache / 2);
     });
   });


### PR DESCRIPTION
As of `duo@0.13.1`, the underlying cache system has been heavily revised and now exposes caching capability to plugins like this one.

The gist is, based on a hash of both the input source code _and_ the configured options, a unique key is generated that will be used to cache the results of `myth()`. This should speed things up considerably when no CSS files were actually changed since the last build.

This change to the plugin is **not** backwards-compatible with `duo@<0.13.1`, so I will likely be bumping major on this particular release.
